### PR TITLE
Fix the Travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 sudo: false
 language: scala
 scala:
-- 2.10.4
+- 2.11.6
 jdk:
 - oraclejdk8
 cache:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: scala
 scala:
 - 2.10.4
 jdk:
-- oraclejdk7
+- oraclejdk8
 cache:
   directories:
     - '$HOME/.ivy2/cache'

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -3,7 +3,7 @@ logLevel := Level.Info
 resolvers += Resolver.url("hmrc-sbt-plugin-releases",
   url("https://dl.bintray.com/hmrc/sbt-plugin-releases"))(Resolver.ivyStylePatterns)
 
-addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "0.8.0")
+addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "1.0.0")
 
 addSbtPlugin("uk.gov.hmrc" % "sbt-git-versioning" % "0.8.0")
 


### PR DESCRIPTION
Fix Travis build by:
- upgrading Travis config to JDK8 and Scala 2.11.6, in line with the code.
- In order to get the fork working the sbt-auto-build plugin needed upgrading too.
