### PR TITLE
Force connection, idle and request timeouts of 5 minutes.

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,13 @@ There are release and release candidate repositories in Bintray HMRC for standar
 - `-d | --dryRun`: perform a dry run of a relase. Downloads files and transforms but does not upload or create releases on github.com. Useful during development
 - `--github-name-override`: provide a different github repository to the bintray package. The default is to assume the github repository has the same name as the Bintry repository and this flag allows the user to provide a differnt github.com repository name.
 
+#### Configuration Parameters
+You can specify custom timeouts to be passed to the play.ws libraries that this project uses with the following System properties (-Dproperty.name=value)
+
+wsclient.timeout.connection - Connection timeout (seconds)
+wsclient.timeout.idle - Idle timeout (seconds)
+wsclient.timeout.request - Request timeout (seconds)
+
 ### Supported Artifacts
 Releaser will release:
 - Maven based libraries and services found in https://bintray.com/hmrc/release-candidates

--- a/src/main/scala/uk/gov/hmrc/releaser/Bintray.scala
+++ b/src/main/scala/uk/gov/hmrc/releaser/Bintray.scala
@@ -111,10 +111,12 @@ class BintrayHttp(creds:ServiceCredentials){
 
   val log = new Logger()
 
+  private def getTimeoutPropertyOptional(key: String) = Option(System.getProperty(key)).map(_.toLong * 1000)
+
   def wsClientConfig = new DefaultWSClientConfig(
-    connectionTimeout = Some(300000),
-    idleTimeout = Some(300000),
-    requestTimeout = Some(300000)
+    connectionTimeout = getTimeoutPropertyOptional("wsclient.timeout.connection"),
+    idleTimeout = getTimeoutPropertyOptional("wsclient.timeout.idle"),
+    requestTimeout = getTimeoutPropertyOptional("wsclient.timeout.request")
   )
 
   val ws = new NingWSClient(new NingAsyncHttpClientConfigBuilder(wsClientConfig).build())

--- a/src/main/scala/uk/gov/hmrc/releaser/Bintray.scala
+++ b/src/main/scala/uk/gov/hmrc/releaser/Bintray.scala
@@ -111,7 +111,13 @@ class BintrayHttp(creds:ServiceCredentials){
 
   val log = new Logger()
 
-  val ws = new NingWSClient(new NingAsyncHttpClientConfigBuilder(new DefaultWSClientConfig).build())
+  def wsClientConfig = new DefaultWSClientConfig(
+    connectionTimeout = Some(300000),
+    idleTimeout = Some(300000),
+    requestTimeout = Some(300000)
+  )
+
+  val ws = new NingWSClient(new NingAsyncHttpClientConfigBuilder(wsClientConfig).build())
 
 
   def apiWs(url:String) = ws.url(url)
@@ -157,7 +163,6 @@ class BintrayHttp(creds:ServiceCredentials){
       .withHeaders(
         "X-Bintray-Package" -> version.artefactName,
         "X-Bintray-Version" -> version.version.value)
-      .withRequestTimeout((5 minutes).toMillis.toInt)
       .put(file.toFile)
 
     val result: WSResponse = Await.result(call, Duration.apply(6, TimeUnit.MINUTES))

--- a/src/main/scala/uk/gov/hmrc/releaser/Releaser.scala
+++ b/src/main/scala/uk/gov/hmrc/releaser/Releaser.scala
@@ -90,7 +90,6 @@ object Releaser {
              ):Int={
     val tmpDir = Files.createTempDirectory("releaser")
 
-
     val githubCredsFile  = System.getProperty("user.home") + "/.github/.credentials"
     val bintrayCredsFile = System.getProperty("user.home") + "/.bintray/.credentials"
 


### PR DESCRIPTION
In a full play application timeouts can be passed as config parameters, e.g. -Dws.timeout.connection=300

Since we're just borrowing play libraries here that won't work, and since we don't have a config mechanism of we're own we need to hard code these preferences.
