### PR TITLE
add option to specify custom release notes appended at the bottom of the default ones

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 [![Build Status](https://travis-ci.org/hmrc/releaser.svg?branch=master)](https://travis-ci.org/hmrc/releaser) [ ![Download](https://api.bintray.com/packages/hmrc/releases/releaser/images/download.svg) ](https://bintray.com/hmrc/releases/releaser/_latestVersion)
 
-Releases artifacts from release candidates with one command. For use as part of a continuous delivery pipeline in which users can create a release from a development commit and create a tag in Github with one command. This automates numerous manual steps required to release an artifact with the existing [release](https://github.com/hmrc/release) scripts.
+Releases artefacts from release candidates with one command. For use as part of a continuous delivery pipeline in which users can create a release from a development commit and create a tag in Github with one command. This automates numerous manual steps required to release an artefact with the existing [release](https://github.com/hmrc/release) scripts.
 
-The release candidate is a published artifact in a Bintray HMRC release candidate repository. Releaser works by taking a release candidate, modifying the verion numbers in the Manifest and file names and uploading files back to Bintray. *All compiled files are not touched in this process*.  
+The release candidate is a published artefact in a Bintray HMRC release candidate repository. Releaser works by taking a release candidate, modifying the verion numbers in the Manifest and file names and uploading files back to Bintray. *All compiled files are not touched in this process*.  
 
 There are release and release candidate repositories in Bintray HMRC for standard (maven) projects and sbt-plugins which are in the Ivy style.
 

--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 [![Build Status](https://travis-ci.org/hmrc/releaser.svg?branch=master)](https://travis-ci.org/hmrc/releaser) [ ![Download](https://api.bintray.com/packages/hmrc/releases/releaser/images/download.svg) ](https://bintray.com/hmrc/releases/releaser/_latestVersion)
 
-Releases artefacts from release candidates with one command. For use as part of a continuous delivery pipeline in which users can create a release from a development commit and create a tag in Github with one command. This automates numerous manual steps required to release an artefact with the existing [release](https://github.com/hmrc/release) scripts.
+Releases artifacts from release candidates with one command. For use as part of a continuous delivery pipeline in which users can create a release from a development commit and create a tag in Github with one command. This automates numerous manual steps required to release an artifact with the existing [release](https://github.com/hmrc/release) scripts.
 
-The release candidate is a published artefact in a Bintray HMRC release candidate repository. Releaser works by taking a release candidate, modifying the verion numbers in the Manifest and file names and uploading files back to Bintray. *All compiled files are not touched in this process*.  
+The release candidate is a published artifact in a Bintray HMRC release candidate repository. Releaser works by taking a release candidate, modifying the verion numbers in the Manifest and file names and uploading files back to Bintray. *All compiled files are not touched in this process*.  
 
 There are release and release candidate repositories in Bintray HMRC for standard (maven) projects and sbt-plugins which are in the Ivy style.
 
@@ -15,8 +15,9 @@ There are release and release candidate repositories in Bintray HMRC for standar
 `java -jar target/scala-2.11/releaser-assembly-x.x.x.jar` artifact release-candidate-version release-version
 
 ##### Extra flags
-- `-d | --dryRun`: perform a dry run of a relase. Downloads files and transforms but does not upload or create releases on github.com. Useful during development
-- `--github-name-override`: provide a different github repository to the bintray package. The default is to assume the github repository has the same name as the Bintry repository and this flag allows the user to provide a differnt github.com repository name.
+- `-d | --dryRun`: perform a dry run of a release. Downloads files and transforms but does not upload or create releases on github.com. Useful during development
+- `--github-name-override`: provide a different github repository to the bintray package. The default is to assume the github repository has the same name as the Bintry repository and this flag allows the user to provide a different github.com repository name.
+- `--release-notes`: custom release notes appended at the bottom of the default
 
 #### Configuration Parameters
 You can specify custom timeouts to be passed to the play.ws libraries that this project uses with the following System properties (-Dproperty.name=value)

--- a/src/main/scala/uk/gov/hmrc/releaser/ArgParser.scala
+++ b/src/main/scala/uk/gov/hmrc/releaser/ArgParser.scala
@@ -25,7 +25,8 @@ object ArgParser{
                      githubNameOverride:Option[String] = None,
                      tag:Boolean = true,
                      verbose:Boolean = false,
-                     dryRun:Boolean = false)
+                     dryRun:Boolean = false,
+                     releaseNotes: String = "")
 
   val currentVersion = getClass.getPackage.getImplementationVersion
 
@@ -41,6 +42,8 @@ object ArgParser{
       c.copy(releaseType = ReleaseType.withName(x)) } validate { x =>
        if (ReleaseType.stringValues.contains(x)) success else failure(releaseTypeErrorMessage(x))
     } text "the release type. Permitted values are: " + ReleaseType.stringValues.mkString(" ")
+    opt[String]("release-notes") action { (x, c) =>
+      c.copy(releaseNotes = x) } text "release notes"
     opt[Boolean]("tag") action { (x, c) =>
       c.copy(tag = x) } text "tag in github"
     opt[String]("github-name-override") action { (x, c) =>

--- a/src/main/scala/uk/gov/hmrc/releaser/ArgParser.scala
+++ b/src/main/scala/uk/gov/hmrc/releaser/ArgParser.scala
@@ -26,7 +26,7 @@ object ArgParser{
                      tag:Boolean = true,
                      verbose:Boolean = false,
                      dryRun:Boolean = false,
-                     releaseNotes: String = "")
+                     releaseNotes: Option[String] = None)
 
   val currentVersion = getClass.getPackage.getImplementationVersion
 
@@ -43,7 +43,7 @@ object ArgParser{
        if (ReleaseType.stringValues.contains(x)) success else failure(releaseTypeErrorMessage(x))
     } text "the release type. Permitted values are: " + ReleaseType.stringValues.mkString(" ")
     opt[String]("release-notes") action { (x, c) =>
-      c.copy(releaseNotes = x) } text "release notes"
+      c.copy(releaseNotes = Some(x)) } text "release notes"
     opt[Boolean]("tag") action { (x, c) =>
       c.copy(tag = x) } text "tag in github"
     opt[String]("github-name-override") action { (x, c) =>

--- a/src/main/scala/uk/gov/hmrc/releaser/Coordinator.scala
+++ b/src/main/scala/uk/gov/hmrc/releaser/Coordinator.scala
@@ -36,7 +36,8 @@ class Coordinator(stageDir: Path,
   def start(artefactName:String,
             gitRepo:Repo,
             releaseCandidateVersion: ReleaseCandidateVersion,
-            releaseType: ReleaseType.Value): Try[ReleaseVersion] = {
+            releaseType: ReleaseType.Value,
+            releaseNotes: String): Try[ReleaseVersion] = {
 
     for {
       targetVersion <- VersionNumberCalculator.calculateTarget(releaseCandidateVersion, releaseType)
@@ -51,7 +52,7 @@ class Coordinator(stageDir: Path,
       transd <- transformFiles(repo, map, remotes)
       _ <- uploadFiles(repo, map.targetArtefact, transd)
       _ <- bintrayConnector.publish(map.targetArtefact)
-      _ <- githubConnector.createGithubTagAndRelease(new DateTime(), commitSha, commitAuthor, commitDate, artefactName, gitRepo, releaseCandidateVersion.value, targetVersion.value)
+      _ <- githubConnector.createGithubTagAndRelease(new DateTime(), commitSha, commitAuthor, commitDate, artefactName, gitRepo, releaseCandidateVersion.value, targetVersion.value, releaseNotes)
     }
      yield targetVersion
   }

--- a/src/main/scala/uk/gov/hmrc/releaser/Coordinator.scala
+++ b/src/main/scala/uk/gov/hmrc/releaser/Coordinator.scala
@@ -37,7 +37,7 @@ class Coordinator(stageDir: Path,
             gitRepo:Repo,
             releaseCandidateVersion: ReleaseCandidateVersion,
             releaseType: ReleaseType.Value,
-            releaseNotes: String): Try[ReleaseVersion] = {
+            releaseNotes: Option[String]): Try[ReleaseVersion] = {
 
     for {
       targetVersion <- VersionNumberCalculator.calculateTarget(releaseCandidateVersion, releaseType)

--- a/src/main/scala/uk/gov/hmrc/releaser/Releaser.scala
+++ b/src/main/scala/uk/gov/hmrc/releaser/Releaser.scala
@@ -46,7 +46,7 @@ object Releaser extends Logger {
     }
   }
 
-  def run(artefactName: String, rcVersion: ReleaseCandidateVersion, releaseType: ReleaseType.Value, gitHubName: String, releaseNotes: String, dryRun: Boolean = false): Int = {
+  def run(artefactName: String, rcVersion: ReleaseCandidateVersion, releaseType: ReleaseType.Value, gitHubName: String, releaseNotes: Option[String], dryRun: Boolean = false): Int = {
     val githubCredsFile = System.getProperty("user.home") + "/.github/.credentials"
     val bintrayCredsFile = System.getProperty("user.home") + "/.bintray/.credentials"
 

--- a/src/main/scala/uk/gov/hmrc/releaser/Releaser.scala
+++ b/src/main/scala/uk/gov/hmrc/releaser/Releaser.scala
@@ -41,12 +41,12 @@ object Releaser extends Logger {
     parser.parse(args, Config()) match {
       case Some(config) =>
         val githubName = config.githubNameOverride.getOrElse(config.artefactName)
-        run(config.artefactName, ReleaseCandidateVersion(config.rcVersion), config.releaseType, githubName, config.dryRun)
+        run(config.artefactName, ReleaseCandidateVersion(config.rcVersion), config.releaseType, githubName, config.releaseNotes, config.dryRun)
       case None => -1
     }
   }
 
-  def run(artefactName: String, rcVersion: ReleaseCandidateVersion, releaseType: ReleaseType.Value, gitHubName: String, dryRun: Boolean = false): Int = {
+  def run(artefactName: String, rcVersion: ReleaseCandidateVersion, releaseType: ReleaseType.Value, gitHubName: String, releaseNotes: String, dryRun: Boolean = false): Int = {
     val githubCredsFile = System.getProperty("user.home") + "/.github/.credentials"
     val bintrayCredsFile = System.getProperty("user.home") + "/.bintray/.credentials"
 
@@ -69,7 +69,7 @@ object Releaser extends Logger {
         val bintrayRepoConnector = new DefaultBintrayRepoConnector(directories.workDir, new BintrayHttp(bintrayCredsOpt.get), new FileDownloader)
 
         val coordinator = new Coordinator(directories.stageDir, metaDataProvider, gitHubDetails, bintrayRepoConnector)
-        val result = coordinator.start(artefactName, Repo(gitHubName), rcVersion, releaseType)
+        val result = coordinator.start(artefactName, Repo(gitHubName), rcVersion, releaseType, releaseNotes)
 
         result match {
           case Success(targetVersion) =>

--- a/src/main/scala/uk/gov/hmrc/releaser/github/GithubConnector.scala
+++ b/src/main/scala/uk/gov/hmrc/releaser/github/GithubConnector.scala
@@ -68,11 +68,12 @@ class GithubConnector(githubHttp : GithubHttp, releaserVersion : String, comitte
 
   def createGithubTagAndRelease(tagDate: DateTime, commitSha: CommitSha,
                                  commitAuthor: String, commitDate: DateTime,
-                                 artefactName: String, gitRepo: Repo, releaseCandidateVersion: String, version: String): Try[Unit] =
+                                 artefactName: String, gitRepo: Repo, releaseCandidateVersion: String, version: String,
+                                 releaseNotes: String): Try[Unit] =
     for (
       tagSha <- createTagObject(tagDate, gitRepo, version, commitSha);
       _ <- createTagRef(gitRepo, version, tagSha);
-      _ <- createRelease(commitSha, commitAuthor, commitDate, artefactName, gitRepo, releaseCandidateVersion, version))
+      _ <- createRelease(commitSha, commitAuthor, commitDate, artefactName, gitRepo, releaseCandidateVersion, version, releaseNotes))
       yield ()
 
   private def createTagObject(tagDate: DateTime, repo:Repo, tag: String, commitSha:CommitSha): Try[CommitSha] = {
@@ -95,11 +96,12 @@ class GithubConnector(githubHttp : GithubHttp, releaserVersion : String, comitte
 
   private def createRelease(commitSha: CommitSha, commitAuthor: String,
                             commitDate: DateTime, artefactName: String,
-                            gitRepo: Repo, releaseCandidateVersion: String, version: String): Try[Unit] = {
+                            gitRepo: Repo, releaseCandidateVersion: String, version: String,
+                            releaseNotes: String): Try[Unit] = {
     log.debug(s"creating release from $commitSha version " + version)
 
     val url = buildReleasePostUrl(gitRepo)
-    val message = buildMessage(artefactName, version, releaserVersion, releaseCandidateVersion, commitSha, commitAuthor, commitDate)
+    val message = buildMessage(artefactName, version, releaserVersion, releaseCandidateVersion, commitSha, commitAuthor, commitDate, releaseNotes)
     val body = buildReleaseBody(message, version)
 
     githubHttp.postUnit(url, body)
@@ -125,7 +127,8 @@ class GithubConnector(githubHttp : GithubHttp, releaserVersion : String, comitte
                     version: String,
                     releaserVersion: String,
                     releaseCandidateVersion: String,
-                    commitSha: CommitSha, commitAuthor: String, commitDate: DateTime) =
+                    commitSha: CommitSha, commitAuthor: String, commitDate: DateTime,
+                    releaseNotes: String) =
     s"""
       |Release            : $name $version
       |Release candidate  : $name $releaseCandidateVersion
@@ -134,7 +137,10 @@ class GithubConnector(githubHttp : GithubHttp, releaserVersion : String, comitte
       |Last commit author : $commitAuthor
       |Last commit time   : ${DateTimeFormat.longDateTime().print(commitDate)}
       |
-      |Release and tag created by [Releaser](https://github.com/hmrc/releaser) $releaserVersion""".stripMargin
+      |Release and tag created by [Releaser](https://github.com/hmrc/releaser) $releaserVersion
+      |
+      |$releaseNotes
+      |""".stripMargin
 
   private def buildCommitGetUrl(repo:Repo, sha:CommitSha)={
     s"https://api.github.com/repos/hmrc/${repo.value}/git/commits/$sha"
@@ -161,5 +167,5 @@ class DryRunGithubConnector(releaserVersion: String) extends GithubTagAndRelease
 
   def createGithubTagAndRelease(tagDate: DateTime, commitSha: CommitSha,
     commitAuthor: String, commitDate: DateTime,
-    artefactName: String, gitRepo: Repo, releaseCandidateVersion: String, version: String): Try[Unit] = Success(Unit)
+    artefactName: String, gitRepo: Repo, releaseCandidateVersion: String, version: String, releaseNotes: String): Try[Unit] = Success(Unit)
 }

--- a/src/main/scala/uk/gov/hmrc/releaser/github/GithubTagAndRelease.scala
+++ b/src/main/scala/uk/gov/hmrc/releaser/github/GithubTagAndRelease.scala
@@ -32,6 +32,6 @@ trait GithubTagAndRelease {
                                 gitRepo: Repo,
                                 releaseCandidateVersion: String,
                                 version: String,
-                                releaseNotes: String): Try[Unit]
+                                releaseNotes: Option[String]): Try[Unit]
 
 }

--- a/src/main/scala/uk/gov/hmrc/releaser/github/GithubTagAndRelease.scala
+++ b/src/main/scala/uk/gov/hmrc/releaser/github/GithubTagAndRelease.scala
@@ -22,10 +22,16 @@ import scala.util.Try
 
 trait GithubTagAndRelease {
 
-  def verifyGithubTagExists(repo:Repo, sha:CommitSha): Try[Unit]
+  def verifyGithubTagExists(repo: Repo, sha: CommitSha): Try[Unit]
 
-  def createGithubTagAndRelease(tagDate: DateTime, commitSha: CommitSha,
-                                commitAuthor: String, commitDate: DateTime,
-                                artefactName: String, gitRepo: Repo, releaseCandidateVersion: String, version: String): Try[Unit]
+  def createGithubTagAndRelease(tagDate: DateTime,
+                                commitSha: CommitSha,
+                                commitAuthor: String,
+                                commitDate: DateTime,
+                                artefactName: String,
+                                gitRepo: Repo,
+                                releaseCandidateVersion: String,
+                                version: String,
+                                releaseNotes: String): Try[Unit]
 
 }

--- a/src/test/scala/uk/gov/hmrc/releaser/CoordinatorSpecs.scala
+++ b/src/test/scala/uk/gov/hmrc/releaser/CoordinatorSpecs.scala
@@ -57,7 +57,7 @@ class CoordinatorSpecs extends WordSpec with Matchers with OptionValues with Try
         bintrayFiles = Set(s"$root/libr_2.11-1.3.0-1-g21312cc.pom", s"$root/libr_2.11-1.3.0-1-g21312cc-assembly.jar"))
 
       val coordinator = new Coordinator(tempDir(), metaDataProvider, new FakeGithubTagAndRelease, fakeRepoConnector)
-      coordinator.start("libr", Repo("libr"), ReleaseCandidateVersion("1.3.0-1-g21312cc"), ReleaseType.HOTFIX) match {
+      coordinator.start("libr", Repo("libr"), ReleaseCandidateVersion("1.3.0-1-g21312cc"), ReleaseType.HOTFIX, "some release notes") match {
         case Failure(e) =>
           log.error(s"Test failed with: ${e.getMessage} - ${e.toString}")
           fail(e)
@@ -106,7 +106,7 @@ class CoordinatorSpecs extends WordSpec with Matchers with OptionValues with Try
           s"$root/help-frontend_2.11-1.26.0-3-gd7ed03c-sources.jar"))
 
       val coordinator = new Coordinator(tempDir(), metaDataProvider, new FakeGithubTagAndRelease, fakeRepoConnector)
-      coordinator.start("help-frontend", Repo("help-frontend"), ReleaseCandidateVersion("1.26.0-3-gd7ed03c"), ReleaseType.MAJOR) match {
+      coordinator.start("help-frontend", Repo("help-frontend"), ReleaseCandidateVersion("1.26.0-3-gd7ed03c"), ReleaseType.MAJOR, "some release notes") match {
         case Failure(e) =>
           log.error(s"Test failed with: ${e.getMessage} - ${e.toString}")
           fail(e)
@@ -143,7 +143,7 @@ class CoordinatorSpecs extends WordSpec with Matchers with OptionValues with Try
         bintrayFiles = Set(s"$root/time_2.11-1.3.0-1-g21312cc.pom"))
 
       val coordinator = new Coordinator(tempDir(), metaDataProvider, new FakeGithubTagAndRelease, fakeRepoConnector)
-      coordinator.start("time", Repo("time"), ReleaseCandidateVersion("1.3.0-1-g21312cc"), ReleaseType.MINOR) match {
+      coordinator.start("time", Repo("time"), ReleaseCandidateVersion("1.3.0-1-g21312cc"), ReleaseType.MINOR, "some release notes") match {
         case Failure(e) =>
           log.error(s"Test failed with: ${e.getMessage} - ${e.toString}")
           fail(e)
@@ -184,7 +184,7 @@ class CoordinatorSpecs extends WordSpec with Matchers with OptionValues with Try
         ))
 
       val coordinator = new Coordinator(tempDir(), metaDataProvider, new FakeGithubTagAndRelease, fakeBintrayRepoConnector)
-      coordinator.start("time", Repo("time"), ReleaseCandidateVersion("1.3.0-1-g21312cc"), ReleaseType.MINOR) match {
+      coordinator.start("time", Repo("time"), ReleaseCandidateVersion("1.3.0-1-g21312cc"), ReleaseType.MINOR, "some release notes") match {
         case Failure(e) =>
           log.error(s"Test failed with: ${e.getMessage} - ${e.toString}")
           fail(e)
@@ -228,7 +228,7 @@ class CoordinatorSpecs extends WordSpec with Matchers with OptionValues with Try
           s"$root/paye-estimator_sjs0.6_2.11-0.1.0-1-g1906708-javadoc.jar"))
  
       val coordinator = new Coordinator(tempDir(), metaDataProvider, new FakeGithubTagAndRelease, fakeRepoConnector)
-      coordinator.start("paye-estimator", Repo("paye-estimator"), ReleaseCandidateVersion("0.1.0-1-g1906708"), ReleaseType.MINOR) match {
+      coordinator.start("paye-estimator", Repo("paye-estimator"), ReleaseCandidateVersion("0.1.0-1-g1906708"), ReleaseType.MINOR, "some release notes") match {
         case Failure(e) =>
           log.error(s"Test failed with: ${e.getMessage} - ${e.toString}")
           fail(e)
@@ -272,7 +272,7 @@ class CoordinatorSpecs extends WordSpec with Matchers with OptionValues with Try
           s"$root/paye-estimator_sjs0.6_2.11-0.1.0-1-g1906708.zip"))
 
       val coordinator = new Coordinator(tempDir(), metaDataProvider, new FakeGithubTagAndRelease, fakeRepoConnector)
-      coordinator.start("paye-estimator", Repo("paye-estimator"), ReleaseCandidateVersion("0.1.0-1-g1906708"), ReleaseType.MINOR) match {
+      coordinator.start("paye-estimator", Repo("paye-estimator"), ReleaseCandidateVersion("0.1.0-1-g1906708"), ReleaseType.MINOR, "some release notes") match {
         case Failure(e) =>
           log.error(s"Test failed with: ${e.getMessage} - ${e.toString}")
           fail(e)
@@ -305,7 +305,7 @@ class CoordinatorSpecs extends WordSpec with Matchers with OptionValues with Try
         bintrayFiles = Set(s"$root/time_2.11-1.3.0-1-g21312cc.pom"))
 
       val coordinator = new Coordinator(tempDir(), metaDataProvider, taggerAndReleaser, fakeRepoConnector)
-      coordinator.start("time", Repo("time"), aReleaseCandidateVersion, ReleaseType.MINOR) match {
+      coordinator.start("time", Repo("time"), aReleaseCandidateVersion, ReleaseType.MINOR, "some release notes") match {
         case Failure(e) => e shouldBe expectedException
         case Success(s) => fail(s"Should have failed with $expectedException")
       }
@@ -320,7 +320,7 @@ class CoordinatorSpecs extends WordSpec with Matchers with OptionValues with Try
         bintrayFiles = Set(s"$root/time_2.11-1.3.0-1-g21312cc.pom"), targetExists = true)
 
       val coordinator = new Coordinator(tempDir(), mock[MetaDataProvider], new FakeGithubTagAndRelease, fakeRepoConnector)
-      coordinator.start("time", Repo("time"), aReleaseCandidateVersion, ReleaseType.MINOR) match {
+      coordinator.start("time", Repo("time"), aReleaseCandidateVersion, ReleaseType.MINOR, "some release notes") match {
         case Failure(e) => e shouldBe an [IllegalArgumentException]
         case Success(s) => fail(s"Should have failed with an IllegalArgumentException")
       }
@@ -333,7 +333,7 @@ class CoordinatorSpecs extends WordSpec with Matchers with OptionValues with Try
       }
 
       val coordinator = new Coordinator(tempDir(), mock[MetaDataProvider], new FakeGithubTagAndRelease, fakeRepoConnector)
-      coordinator.start("a", Repo("a"), aReleaseCandidateVersion, ReleaseType.MINOR) match {
+      coordinator.start("a", Repo("a"), aReleaseCandidateVersion, ReleaseType.MINOR, "some release notes") match {
         case Failure(e) => e.getMessage shouldBe "Didn't find a release candidate repository for 'a' in repos List(release-candidates, sbt-plugin-release-candidates)"
         case Success(s) => fail(s"Should have failed")
       }
@@ -357,7 +357,7 @@ class CoordinatorSpecs extends WordSpec with Matchers with OptionValues with Try
       }
 
       val coordinator = new Coordinator(tempDir(), metaDataProvider, new FakeGithubTagAndRelease, fakeRepoConnector)
-      coordinator.start("sbt-bobby", Repo("sbt-bobby"), ReleaseCandidateVersion("0.8.1-4-ge733d26"), ReleaseType.HOTFIX) match {
+      coordinator.start("sbt-bobby", Repo("sbt-bobby"), ReleaseCandidateVersion("0.8.1-4-ge733d26"), ReleaseType.HOTFIX, "some release notes") match {
           case Failure(e) =>
             log.error(s"Test failed with: ${e.getMessage} - ${e.toString}")
             fail(e)

--- a/src/test/scala/uk/gov/hmrc/releaser/CoordinatorSpecs.scala
+++ b/src/test/scala/uk/gov/hmrc/releaser/CoordinatorSpecs.scala
@@ -57,7 +57,7 @@ class CoordinatorSpecs extends WordSpec with Matchers with OptionValues with Try
         bintrayFiles = Set(s"$root/libr_2.11-1.3.0-1-g21312cc.pom", s"$root/libr_2.11-1.3.0-1-g21312cc-assembly.jar"))
 
       val coordinator = new Coordinator(tempDir(), metaDataProvider, new FakeGithubTagAndRelease, fakeRepoConnector)
-      coordinator.start("libr", Repo("libr"), ReleaseCandidateVersion("1.3.0-1-g21312cc"), ReleaseType.HOTFIX, "some release notes") match {
+      coordinator.start("libr", Repo("libr"), ReleaseCandidateVersion("1.3.0-1-g21312cc"), ReleaseType.HOTFIX, None) match {
         case Failure(e) =>
           log.error(s"Test failed with: ${e.getMessage} - ${e.toString}")
           fail(e)
@@ -106,7 +106,7 @@ class CoordinatorSpecs extends WordSpec with Matchers with OptionValues with Try
           s"$root/help-frontend_2.11-1.26.0-3-gd7ed03c-sources.jar"))
 
       val coordinator = new Coordinator(tempDir(), metaDataProvider, new FakeGithubTagAndRelease, fakeRepoConnector)
-      coordinator.start("help-frontend", Repo("help-frontend"), ReleaseCandidateVersion("1.26.0-3-gd7ed03c"), ReleaseType.MAJOR, "some release notes") match {
+      coordinator.start("help-frontend", Repo("help-frontend"), ReleaseCandidateVersion("1.26.0-3-gd7ed03c"), ReleaseType.MAJOR, None) match {
         case Failure(e) =>
           log.error(s"Test failed with: ${e.getMessage} - ${e.toString}")
           fail(e)
@@ -143,7 +143,7 @@ class CoordinatorSpecs extends WordSpec with Matchers with OptionValues with Try
         bintrayFiles = Set(s"$root/time_2.11-1.3.0-1-g21312cc.pom"))
 
       val coordinator = new Coordinator(tempDir(), metaDataProvider, new FakeGithubTagAndRelease, fakeRepoConnector)
-      coordinator.start("time", Repo("time"), ReleaseCandidateVersion("1.3.0-1-g21312cc"), ReleaseType.MINOR, "some release notes") match {
+      coordinator.start("time", Repo("time"), ReleaseCandidateVersion("1.3.0-1-g21312cc"), ReleaseType.MINOR, None) match {
         case Failure(e) =>
           log.error(s"Test failed with: ${e.getMessage} - ${e.toString}")
           fail(e)
@@ -184,7 +184,7 @@ class CoordinatorSpecs extends WordSpec with Matchers with OptionValues with Try
         ))
 
       val coordinator = new Coordinator(tempDir(), metaDataProvider, new FakeGithubTagAndRelease, fakeBintrayRepoConnector)
-      coordinator.start("time", Repo("time"), ReleaseCandidateVersion("1.3.0-1-g21312cc"), ReleaseType.MINOR, "some release notes") match {
+      coordinator.start("time", Repo("time"), ReleaseCandidateVersion("1.3.0-1-g21312cc"), ReleaseType.MINOR, None) match {
         case Failure(e) =>
           log.error(s"Test failed with: ${e.getMessage} - ${e.toString}")
           fail(e)
@@ -228,7 +228,7 @@ class CoordinatorSpecs extends WordSpec with Matchers with OptionValues with Try
           s"$root/paye-estimator_sjs0.6_2.11-0.1.0-1-g1906708-javadoc.jar"))
  
       val coordinator = new Coordinator(tempDir(), metaDataProvider, new FakeGithubTagAndRelease, fakeRepoConnector)
-      coordinator.start("paye-estimator", Repo("paye-estimator"), ReleaseCandidateVersion("0.1.0-1-g1906708"), ReleaseType.MINOR, "some release notes") match {
+      coordinator.start("paye-estimator", Repo("paye-estimator"), ReleaseCandidateVersion("0.1.0-1-g1906708"), ReleaseType.MINOR, None) match {
         case Failure(e) =>
           log.error(s"Test failed with: ${e.getMessage} - ${e.toString}")
           fail(e)
@@ -272,7 +272,7 @@ class CoordinatorSpecs extends WordSpec with Matchers with OptionValues with Try
           s"$root/paye-estimator_sjs0.6_2.11-0.1.0-1-g1906708.zip"))
 
       val coordinator = new Coordinator(tempDir(), metaDataProvider, new FakeGithubTagAndRelease, fakeRepoConnector)
-      coordinator.start("paye-estimator", Repo("paye-estimator"), ReleaseCandidateVersion("0.1.0-1-g1906708"), ReleaseType.MINOR, "some release notes") match {
+      coordinator.start("paye-estimator", Repo("paye-estimator"), ReleaseCandidateVersion("0.1.0-1-g1906708"), ReleaseType.MINOR, None) match {
         case Failure(e) =>
           log.error(s"Test failed with: ${e.getMessage} - ${e.toString}")
           fail(e)
@@ -305,7 +305,7 @@ class CoordinatorSpecs extends WordSpec with Matchers with OptionValues with Try
         bintrayFiles = Set(s"$root/time_2.11-1.3.0-1-g21312cc.pom"))
 
       val coordinator = new Coordinator(tempDir(), metaDataProvider, taggerAndReleaser, fakeRepoConnector)
-      coordinator.start("time", Repo("time"), aReleaseCandidateVersion, ReleaseType.MINOR, "some release notes") match {
+      coordinator.start("time", Repo("time"), aReleaseCandidateVersion, ReleaseType.MINOR, None) match {
         case Failure(e) => e shouldBe expectedException
         case Success(s) => fail(s"Should have failed with $expectedException")
       }
@@ -320,7 +320,7 @@ class CoordinatorSpecs extends WordSpec with Matchers with OptionValues with Try
         bintrayFiles = Set(s"$root/time_2.11-1.3.0-1-g21312cc.pom"), targetExists = true)
 
       val coordinator = new Coordinator(tempDir(), mock[MetaDataProvider], new FakeGithubTagAndRelease, fakeRepoConnector)
-      coordinator.start("time", Repo("time"), aReleaseCandidateVersion, ReleaseType.MINOR, "some release notes") match {
+      coordinator.start("time", Repo("time"), aReleaseCandidateVersion, ReleaseType.MINOR, None) match {
         case Failure(e) => e shouldBe an [IllegalArgumentException]
         case Success(s) => fail(s"Should have failed with an IllegalArgumentException")
       }
@@ -333,7 +333,7 @@ class CoordinatorSpecs extends WordSpec with Matchers with OptionValues with Try
       }
 
       val coordinator = new Coordinator(tempDir(), mock[MetaDataProvider], new FakeGithubTagAndRelease, fakeRepoConnector)
-      coordinator.start("a", Repo("a"), aReleaseCandidateVersion, ReleaseType.MINOR, "some release notes") match {
+      coordinator.start("a", Repo("a"), aReleaseCandidateVersion, ReleaseType.MINOR, None) match {
         case Failure(e) => e.getMessage shouldBe "Didn't find a release candidate repository for 'a' in repos List(release-candidates, sbt-plugin-release-candidates)"
         case Success(s) => fail(s"Should have failed")
       }
@@ -357,7 +357,7 @@ class CoordinatorSpecs extends WordSpec with Matchers with OptionValues with Try
       }
 
       val coordinator = new Coordinator(tempDir(), metaDataProvider, new FakeGithubTagAndRelease, fakeRepoConnector)
-      coordinator.start("sbt-bobby", Repo("sbt-bobby"), ReleaseCandidateVersion("0.8.1-4-ge733d26"), ReleaseType.HOTFIX, "some release notes") match {
+      coordinator.start("sbt-bobby", Repo("sbt-bobby"), ReleaseCandidateVersion("0.8.1-4-ge733d26"), ReleaseType.HOTFIX, None) match {
           case Failure(e) =>
             log.error(s"Test failed with: ${e.getMessage} - ${e.toString}")
             fail(e)

--- a/src/test/scala/uk/gov/hmrc/releaser/github/FakeGithubTagAndRelease.scala
+++ b/src/test/scala/uk/gov/hmrc/releaser/github/FakeGithubTagAndRelease.scala
@@ -22,7 +22,7 @@ import scala.util.{Success, Try}
 class FakeGithubTagAndRelease extends GithubTagAndRelease {
   override def createGithubTagAndRelease(tagDate: DateTime, commitSha: CommitSha,
                                          commitAuthor: String, commitDate: DateTime,
-                                         artefactName: String, gitRepo: Repo, releaseCandidateVersion: String, version: String, releaseNotes: String): Try[Unit] = Success(Unit)
+                                         artefactName: String, gitRepo: Repo, releaseCandidateVersion: String, version: String, releaseNotes: Option[String]): Try[Unit] = Success(Unit)
 
   override def verifyGithubTagExists(repo: Repo, sha: CommitSha): Try[Unit] = Success(Unit)
 }

--- a/src/test/scala/uk/gov/hmrc/releaser/github/FakeGithubTagAndRelease.scala
+++ b/src/test/scala/uk/gov/hmrc/releaser/github/FakeGithubTagAndRelease.scala
@@ -22,7 +22,7 @@ import scala.util.{Success, Try}
 class FakeGithubTagAndRelease extends GithubTagAndRelease {
   override def createGithubTagAndRelease(tagDate: DateTime, commitSha: CommitSha,
                                          commitAuthor: String, commitDate: DateTime,
-                                         artefactName: String, gitRepo: Repo, releaseCandidateVersion: String, version: String): Try[Unit] = Success(Unit)
+                                         artefactName: String, gitRepo: Repo, releaseCandidateVersion: String, version: String, releaseNotes: String): Try[Unit] = Success(Unit)
 
   override def verifyGithubTagExists(repo: Repo, sha: CommitSha): Try[Unit] = Success(Unit)
 }

--- a/src/test/scala/uk/gov/hmrc/releaser/github/GithubConnectorSpecs.scala
+++ b/src/test/scala/uk/gov/hmrc/releaser/github/GithubConnectorSpecs.scala
@@ -84,7 +84,10 @@ class GithubConnectorSpecs extends WordSpec with Matchers with TryValues with Op
           |Last commit author : $author
           |Last commit time   : ${GithubConnector.releaseMessageDateTimeFormat.print(commitDate)}
           |
-          |Release and tag created by [Releaser](https://github.com/hmrc/releaser) $releaserVersion""".stripMargin))
+          |Release and tag created by [Releaser](https://github.com/hmrc/releaser) $releaserVersion
+          |
+          |some custom release notes
+          |""".stripMargin))
 
       val expectedReleaseBody =
         Json.parse(s"""
@@ -106,7 +109,7 @@ class GithubConnectorSpecs extends WordSpec with Matchers with TryValues with Op
       when(mockHttpConnector.postUnit(meq(s"https://api.github.com/repos/hmrc/$repoName/releases"), meq(expectedReleaseBody)))
         .thenReturn(Success(()))
 
-      val result = connector.createGithubTagAndRelease(tagDate, sha, author, commitDate, artifactName, Repo(repoName), rcVersion, releaseVersion)
+      val result = connector.createGithubTagAndRelease(tagDate, sha, author, commitDate, artifactName, Repo(repoName), rcVersion, releaseVersion, "some custom release notes")
 
       result shouldBe Success(())
     }


### PR DESCRIPTION
This PR opens a way to ammend default release notes generated from git data with some business-releated information provided by the releasing team/person.